### PR TITLE
Adding firewall rules and Hack for infrakit managers

### DIFF
--- a/latest/swarm/google/deploy-template.jinja
+++ b/latest/swarm/google/deploy-template.jinja
@@ -109,6 +109,7 @@ resources:
       properties:
           allowed:
               - IPProtocol: tcp
+              - IPProtocol: udp
           sourceRanges:
               - 172.31.16.0/20
           network: $(ref.{{ env["deployment"] }}-network.selfLink)

--- a/latest/swarm/google/deploy-template.jinja
+++ b/latest/swarm/google/deploy-template.jinja
@@ -112,4 +112,18 @@ resources:
           sourceRanges:
               - 172.31.16.0/20
           network: $(ref.{{ env["deployment"] }}-network.selfLink)
-# vim: set filetype=yaml:
+    - name: {{ env["deployment"] }}-firewall-bootstrap-https
+      type: compute.v1.firewall
+      properties:
+          allowed:
+              - IPProtocol: tcp
+                ports:
+                    - 443
+          sourceRanges:
+              - 128.112.0.0/16
+              - 140.180.0.0/16
+              - 204.153.48.0/23
+              - 66.180.176.0/24
+              - 66.180.180.0/22 
+          network: $(ref.{{ env["deployment"] }}-network.selfLink)
+## vim: set filetype=yaml:

--- a/latest/swarm/infrakit.sh
+++ b/latest/swarm/infrakit.sh
@@ -58,6 +58,9 @@ docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage}} \
        cluster/tag/user={{ var `/cluster/tag/user` }} \
        cluster/tag/project={{ var `/cluster/tag/project` }} \
 
+docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage}} \
+	infrakit remote set manager-cluster \
+	{{ list (var `/cluster/swarm/manager/ips/0`) (var `/cluster/swarm/manager/ips/1`) (var `/cluster/swarm/manager/ips/2`) (var `/cluster/swarm/manager/ips/3`) (var `/cluster/swarm/manager/ips/4`) | join ":24864," }}:24864
 
 echo "Rendering a view of the config groups.json for debugging."
 docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage}} infrakit template {{var `/infrakit/config/root`}}/groups.json


### PR DESCRIPTION
- Open 443 firewall for our ip addresses
- Hack to add new remote location to enable non-leader infrakit managers to automatically search for leader node
